### PR TITLE
Workaround: Include web3-provider-engine as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   },
   "devDependencies": {
     "truffle-hdwallet-provider": "^1.0.0-web3one.0",
-    "oasis-compile": "^1.0.1"
+    "oasis-compile": "^1.0.1",
+    "web3-provider-engine": "^14.1.0"
   },
   "keywords": [
     "web3",


### PR DESCRIPTION
Issue here for truffle -
https://github.com/oasislabs/truffle/issues/4

There appears to be a change in the way dependencies are packaged in truffle which
causes users to include packages that their sources don't need to get past truffle
compilation issues. For now, we are including web3-provider-engine as a dep here so
that users of c-k don't have to explicitly include this dependency to get past:

Error: Cannot find module 'bindings'